### PR TITLE
Исправление selectDataFormatter

### DIFF
--- a/src/components/Select/test/formatter.spec.tsx
+++ b/src/components/Select/test/formatter.spec.tsx
@@ -20,15 +20,17 @@ describe('formatter', () => {
   })
 
   it('should support rest property', () => {
-    const result = selectDataFormatter({
-      array: SelectOptionsWithExtraKeys,
-      label: 'text',
-      value: 'id',
-      rest: true
-    })
+    const result = selectDataFormatter(
+      {
+        array: SelectOptionsWithExtraKeys,
+        label: 'text',
+        value: 'id'
+      },
+      true
+    )
 
     expect(Object.keys(result[0])).toHaveLength(
-      Object.keys(SelectOptionsWithExtraKeys[0]).length
+      Object.keys(SelectOptionsWithExtraKeys[0]).length + 2
     )
     expect(result[0]).toHaveProperty('subtext')
   })

--- a/src/components/Select/types.ts
+++ b/src/components/Select/types.ts
@@ -1,23 +1,18 @@
 import { ComponentPropsWithoutRef, ReactNode } from 'react'
 
-type ArrayElementConstraints<T> = Record<string, T[keyof T]>
-
 export interface DefaultSelectOption {
   value: number | string
   label: string | ReactNode
 }
 
-type MappedObject<T extends ArrayElementConstraints<T>> = {
+type MappedObject<T> = {
   [Property in keyof T]: T[Property]
 }
 
-export type SelectOption<
-  T extends ArrayElementConstraints<T> = Record<string, any>
-> = DefaultSelectOption & MappedObject<T>
+export type SelectOption<T = Record<string, any>> = DefaultSelectOption &
+  MappedObject<T>
 
-export interface SelectDataFormatterOptions<
-  T extends ArrayElementConstraints<T>
-> {
+export interface SelectDataFormatterOptions<T extends Record<string, any>> {
   /**
    * Исходный массив, подлежащий форматированию
    */
@@ -26,15 +21,11 @@ export interface SelectDataFormatterOptions<
    * Строковое название ключа элемента исходного массива, на основании которого будет браться ключ для опции
    * Ключ должен являться уникальным значением
    */
-  value: string
+  value: keyof T
   /**
    * Строковое название ключа элемента исходного массива, на основании которого будет браться текст для отображения опции
    */
-  label: string
-  /**
-   * Нужно ли сохранять остальные поля исходного объекта
-   */
-  rest?: boolean
+  label: keyof T
 }
 
 export interface SelectProps


### PR DESCRIPTION
Breaking changes: в selectDataFormatter проп rest перенесен в отдельный аргумент

Это необходимо для описания вариантов перезрузки и корректной типизации