### PR TITLE
IDD-597 | Ручной ввод при min, max для DatePicker

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -64,6 +64,9 @@ const DatePicker = ({
   const { resetControlValidity } = useFormControlHandlers()
   const required = requiredProp || formGroupContext?.required
 
+  const minDate = min ? new Date(min) : undefined
+  const maxDate = max ? new Date(max) : undefined
+
   // ============================= floating =============================
   const { x, y, refs, context } = useFloating({
     open: isOpened,
@@ -98,7 +101,9 @@ const DatePicker = ({
           size={size}
           placeholder={placeholder}
           mask={{
-            mask: Date
+            mask: Date,
+            min: minDate,
+            max: maxDate
           }}
           pattern={'[0-9]{2}.[0-9]{2}.[0-9]{4}'}
           onComplete={(val) => {

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -24,7 +24,6 @@ import cn from 'classnames'
 import NativeDatePicker from '../DatePicker/components/NaviteDatePicker/NativeDatePicker'
 import FormGroupContext from 'Components/Form/context/group'
 import { formatterFn, validateFn } from 'Components/DateRangePicker/helpers'
-import { IMask } from 'react-imask'
 
 /** Строка в формате YYYY-MM-DD */
 export type DateRangePickerValue = [string | Date, string | Date]
@@ -125,28 +124,12 @@ const DateRangePicker = ({
             }
           }}
           mask={{
-            mask: 'd{.}`m{.}`Y{—}`d{.}`m{.}`Y',
-            blocks: {
-              d: {
-                mask: IMask.MaskedRange,
-                placeholderChar: '_',
-                from: 1,
-                to: 31
-              },
-              m: {
-                mask: IMask.MaskedRange,
-                placeholderChar: '_',
-                from: 1,
-                to: 12
-              },
-              Y: {
-                mask: IMask.MaskedRange,
-                placeholderChar: '_',
-                from: 1000,
-                to: 9999
-              }
-            },
+            // @ts-expect-error
+            mask: Date,
+            pattern: 'd{.}`m{.}`Y{—}`d{.}`m{.}`Y',
+            // @ts-expect-error
             format: (value: string) => formatterFn(value, minDate, maxDate),
+            // @ts-expect-error
             parse: (string) => string,
             validate: (value) => validateFn(value, minDate, maxDate)
           }}

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -24,6 +24,7 @@ import cn from 'classnames'
 import NativeDatePicker from '../DatePicker/components/NaviteDatePicker/NativeDatePicker'
 import FormGroupContext from 'Components/Form/context/group'
 import { formatterFn, validateFn } from 'Components/DateRangePicker/helpers'
+import { IMask } from 'react-imask'
 
 /** Строка в формате YYYY-MM-DD */
 export type DateRangePickerValue = [string | Date, string | Date]
@@ -125,11 +126,28 @@ const DateRangePicker = ({
           }}
           mask={{
             mask: 'd{.}`m{.}`Y{—}`d{.}`m{.}`Y',
-            format: (value: string) => formatterFn(value, minDate, maxDate),
-
-            parse: function (string) {
-              return string
+            blocks: {
+              d: {
+                mask: IMask.MaskedRange,
+                placeholderChar: '_',
+                from: 1,
+                to: 31
+              },
+              m: {
+                mask: IMask.MaskedRange,
+                placeholderChar: '_',
+                from: 1,
+                to: 12
+              },
+              Y: {
+                mask: IMask.MaskedRange,
+                placeholderChar: '_',
+                from: 1000,
+                to: 9999
+              }
             },
+            format: (value: string) => formatterFn(value, minDate, maxDate),
+            parse: (string) => string,
             validate: (value) => validateFn(value, minDate, maxDate)
           }}
           value={displayValue}

--- a/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.tsx
@@ -99,9 +99,7 @@ const DateRangePicker = ({
         <MaskedInput
           placeholder="__.__.____—__.__.____"
           onComplete={(value) => {
-            // Форматируем с учетом min/max
             const formattedValue = formatterFn(value, minDate, maxDate)
-            // Валидируем
             const isValid = validateFn(formattedValue, minDate, maxDate)
 
             if (isValid) {
@@ -115,7 +113,6 @@ const DateRangePicker = ({
                   ) as [string, string]
               )
             } else {
-              // Если не валидно, сбрасываем значение
               onChange?.(['', ''])
             }
           }}

--- a/src/components/DateRangePicker/helpers/index.ts
+++ b/src/components/DateRangePicker/helpers/index.ts
@@ -1,8 +1,10 @@
 import { parseLocalDateString } from 'Utils/date'
 
 /**
- * Функция для валидации того, является ли дата ДО больше даты ОТ
+ * Функция для валидации диапазона дат с учетом min и max
  * @param value format [0-9]{2}.[0-9]{2}.[0-9]{4}—[0-9]{2}.[0-9]{2}.[0-9]{4}
+ * @param min минимальная допустимая дата
+ * @param max максимальная допустимая дата
  */
 export const validateFn = (value: string, min?: Date, max?: Date): boolean => {
   const dates = value?.split('—').map((val) => {
@@ -31,6 +33,12 @@ export const validateFn = (value: string, min?: Date, max?: Date): boolean => {
   return true
 }
 
+/**
+ * Форматирует дату с учетом ограничений min и max
+ * @param date строка с датами
+ * @param min минимальная дата
+ * @param max максимальная дата
+ */
 export const formatterFn = (date: string, min?: Date, max?: Date): string => {
   let [from, to] = date.split('—').map((val) => parseLocalDateString(val)) as [
     Date,

--- a/src/components/DateRangePicker/helpers/index.ts
+++ b/src/components/DateRangePicker/helpers/index.ts
@@ -4,29 +4,51 @@ import { parseLocalDateString } from 'Utils/date'
  * Функция для валидации того, является ли дата ДО больше даты ОТ
  * @param value format [0-9]{2}.[0-9]{2}.[0-9]{4}—[0-9]{2}.[0-9]{2}.[0-9]{4}
  */
-export const validateFn = (value: string): boolean => {
-  const [from, to] = value?.split('—').map((val) => {
-    // если введен год не полностью, не сравниваем даты.
-    // Является обработкой кейса, когда введена дата формата DD.MM.YY и она парсится js как DD.MM.19YY
+export const validateFn = (value: string, min?: Date, max?: Date): boolean => {
+  const dates = value?.split('—').map((val) => {
     if (val.split('.')?.[2]?.length < 4) {
       return undefined
     }
     return parseLocalDateString(val)
-  }) as [Date, Date]
+  }) as [Date | undefined, Date | undefined]
 
-  if (from && to) {
-    return to.getTime() > from.getTime()
+  const [from, to] = dates
+
+  if (from && to && to.getTime() <= from.getTime()) {
+    return false
+  }
+
+  if (min) {
+    if (from && from.getTime() < min.getTime()) return false
+    if (to && to.getTime() < min.getTime()) return false
+  }
+
+  if (max) {
+    if (from && from.getTime() > max.getTime()) return false
+    if (to && to.getTime() > max.getTime()) return false
   }
 
   return true
 }
 
-export const formatterFn = (date: string): string => {
-  const [from, to] = date
-    .split('—')
-    .map((val) => parseLocalDateString(val)) as [Date, Date]
+export const formatterFn = (date: string, min?: Date, max?: Date): string => {
+  let [from, to] = date.split('—').map((val) => parseLocalDateString(val)) as [
+    Date,
+    Date
+  ]
+
   if (from.getFullYear() > to.getFullYear()) {
     to.setFullYear(from.getFullYear())
+  }
+
+  if (min) {
+    if (from.getTime() < min.getTime()) from = new Date(min)
+    if (to.getTime() < min.getTime()) to = new Date(min)
+  }
+
+  if (max) {
+    if (from.getTime() > max.getTime()) from = new Date(max)
+    if (to.getTime() > max.getTime()) to = new Date(max)
   }
 
   const strFrom = from.toLocaleDateString('ru-Ru')

--- a/src/components/DateRangePicker/helpers/index.ts
+++ b/src/components/DateRangePicker/helpers/index.ts
@@ -1,5 +1,14 @@
 import { parseLocalDateString } from 'Utils/date'
 
+export function normalizeDate(date: Date | undefined): Date | undefined {
+  if (!date) {
+    return undefined
+  }
+  const dateCopy = new Date(date)
+  dateCopy.setHours(0, 0, 0, 0)
+  return dateCopy
+}
+
 /**
  * Функция для валидации диапазона дат с учетом min и max
  * @param value format [0-9]{2}.[0-9]{2}.[0-9]{4}—[0-9]{2}.[0-9]{2}.[0-9]{4}
@@ -11,26 +20,20 @@ export const validateFn = (value: string, min?: Date, max?: Date): boolean => {
     if (val.split('.')?.[2]?.length < 4) {
       return undefined
     }
-    return parseLocalDateString(val)
+    return normalizeDate(parseLocalDateString(val))
   }) as [Date | undefined, Date | undefined]
 
   const [from, to] = dates
+  const minDate = normalizeDate(min)
+  const maxDate = normalizeDate(max)
 
-  if (from && to && to.getTime() <= from.getTime()) {
-    return false
-  }
+  const isRangeInvalid = from && to && to <= from
 
-  if (min) {
-    if (from && from.getTime() < min.getTime()) return false
-    if (to && to.getTime() < min.getTime()) return false
-  }
+  const isFromBeforeMin = from && minDate && from < minDate
+  const isToAfterMax = to && maxDate && to > maxDate
+  const isFromAfterMax = from && maxDate && from > maxDate
 
-  if (max) {
-    if (from && from.getTime() > max.getTime()) return false
-    if (to && to.getTime() > max.getTime()) return false
-  }
-
-  return true
+  return !(isRangeInvalid || isFromBeforeMin || isToAfterMax || isFromAfterMax)
 }
 
 /**
@@ -40,23 +43,25 @@ export const validateFn = (value: string, min?: Date, max?: Date): boolean => {
  * @param max максимальная дата
  */
 export const formatterFn = (date: string, min?: Date, max?: Date): string => {
-  let [from, to] = date.split('—').map((val) => parseLocalDateString(val)) as [
-    Date,
-    Date
-  ]
+  let [from, to] = date
+    .split('—')
+    .map((val) => normalizeDate(parseLocalDateString(val))) as [Date, Date]
 
   if (from.getFullYear() > to.getFullYear()) {
     to.setFullYear(from.getFullYear())
   }
 
-  if (min) {
-    if (from.getTime() < min.getTime()) from = new Date(min)
-    if (to.getTime() < min.getTime()) to = new Date(min)
+  const minDate = min ? normalizeDate(min) : undefined
+  const maxDate = max ? normalizeDate(max) : undefined
+
+  if (minDate) {
+    if (from < minDate) from = new Date(minDate)
+    if (to < minDate) to = new Date(minDate)
   }
 
-  if (max) {
-    if (from.getTime() > max.getTime()) from = new Date(max)
-    if (to.getTime() > max.getTime()) to = new Date(max)
+  if (maxDate) {
+    if (from > maxDate) from = new Date(maxDate)
+    if (to > maxDate) to = new Date(maxDate)
   }
 
   const strFrom = from.toLocaleDateString('ru-Ru')


### PR DESCRIPTION
Такое решение срабатывает для DatePicker, но никакие улучшение validateFn formatterFn не позволили применить это к DateRangePicker:
в validateFn разделял строку чтобы получить даты "от" и "до", преобразовывал строки в Date для последующей проверки, параметры min и max сравнивал чтобы они не поменялись местами
в formatterFn хотелось добиться, чтобы даты корректировались автоматически если выходят за пределы min/max,  разделял строку на две сущности,  преобразовывал в Date. Если дата "от" меньше min, устанавливали её значение равным min. Если дата "до" больше max, устанавливали её значение равным max. Если год "до" меньше года "от", выравнивали их, устанавливая год "до" равным году "от".

Решение не сработало, потому что не можем поддерживать частичный ввод, логика самой маски ожидает гибкую обработку с учетом множества параметров, таких как учет года. Обработка такой сложной маски как "две даты в одной строке с учетом min/max" требует большего функционала чем то, что мы можем реализовать в validateFn и formatterFn. Специфичная и сложная маска. 
Кейс задачи легко решается отключением возможности ручного ввода в DateRangePicker в котором есть ограничения по min, max. 

В задаче написано не закапываться в этой задаче, поэтому создаю ПР только для DatePicker 