### PR TITLE
IDD-584 | Modal Исправление флоатинг анимации

### DIFF
--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -47,25 +47,4 @@
     top: 24px;
     right: 24px;
   }
-
-  &--appear,
-  &--enter {
-    opacity: 0;
-  }
-
-  &--appear-active,
-  &--enter-active {
-    opacity: 1;
-    transition: opacity 200ms ease-in;
-  }
-
-  &--exit {
-    opacity: 1;
-  }
-
-  &--exit-active,
-  &--exix-done {
-    opacity: 0;
-    transition: opacity 200ms ease-out;
-  }
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -81,7 +81,9 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     const headingId = useId()
     const descriptionId = useId()
 
-    const { isMounted, status } = useTransitionStatus(context)
+    const { isMounted, status } = useTransitionStatus(context, {
+      duration: 250
+    })
 
     return (
       <FloatingPortal>


### PR DESCRIPTION
При использовании floating библиотеки важно соблюдать duration переданный в хук useTransitionStatus.
The transition duration must match the duration option passed to the Hook.

 Это значение должно быть согласовано между всеми частями системы, чтобы избежать несоответствий. Оно должно совпадать с тем что записано в css для статусов. Несоблюдение правила из документации приводило к непредсказуемым результатам, типа рваных анимаций, удаления элементов до окончания анимации.
 
 Сначала пытался реализовать через отслеживание состояния event transitionend, потом начал изучать библиотеку и там решение оказалось на поверхности