### PR TITLE
IDD-711 | Table. top выравнивание ячеек

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -239,6 +239,7 @@ function BaseTable<TRowData extends Record<string, any>>(
         <table
           className={cn(
             'inf-table',
+            'inf-table--vertical-align-top',
             className,
             {
               [`inf-table--layout-${tableLayout as string}`]: tableLayout


### PR DESCRIPTION
Выравниваем по top как утвердил дизайнер по умолчанию все таблицы Инфинитум.
Использовал уже написанный mixin

было
<img width="952" height="720" alt="image" src="https://github.com/user-attachments/assets/20a61622-144d-4787-9dc9-d8b7f0afe999" />

стало
<img width="979" height="729" alt="image" src="https://github.com/user-attachments/assets/78342c8e-f421-48c6-8dd9-f93dc95f1ad2" />
